### PR TITLE
fix: respect press settings for ansible agent updates

### DIFF
--- a/press/press/doctype/server/server.py
+++ b/press/press/doctype/server/server.py
@@ -478,7 +478,7 @@ class BaseServer(Document, TagHelpers):
 				playbook="update_agent.yml",
 				variables={
 					"agent_repository_url": self.get_agent_repository_url(),
-					"agent_repository_branch_or_commit_ref": "upstream/master",
+					"agent_repository_branch_or_commit_ref": self.get_agent_repository_branch(),
 					"agent_update_args": "",
 				},
 				server=self,


### PR DESCRIPTION
## Summary
- ensure the ad-hoc Ansible agent update uses the repository ref from Press Settings instead of a hard-coded branch

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68dc606498e4832189b3ee9ffdefb3cb